### PR TITLE
Add admin panel menu with aiogram

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,8 +9,10 @@ BOT_TOKEN = os.getenv("BOT_TOKEN")
 # OpenAI API Key
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
-# Admin Telegram ID
-ADMIN_ID = int(os.getenv("ADMIN_ID", "0"))
+# Admin Telegram IDs (comma separated list)
+ADMIN_IDS = [
+    int(x) for x in os.getenv("ADMIN_IDS", "").split(",") if x
+]
 
 # Database
 DATABASE_PATH = "bot_database.db"

--- a/handlers/admin_panel.py
+++ b/handlers/admin_panel.py
@@ -1,0 +1,46 @@
+from aiogram import Router, F
+from aiogram.types import Message
+from aiogram.filters import Command
+
+from config import ADMIN_IDS
+from keyboards.main_keyboard import get_main_keyboard, get_admin_panel_keyboard
+
+router = Router()
+
+
+def is_admin(user_id: int) -> bool:
+    return user_id in ADMIN_IDS
+
+
+@router.message(Command("admin"))
+@router.message(F.text == "🛠 Админ-панель")
+async def admin_menu(message: Message):
+    if not is_admin(message.from_user.id):
+        await message.answer("❌ У вас нет доступа.")
+        return
+    await message.answer("🛠 <b>Админ-панель</b>", reply_markup=get_admin_panel_keyboard())
+
+
+@router.message(F.text == "➕ Добавить товар")
+async def add_product(message: Message):
+    if not is_admin(message.from_user.id):
+        return
+    await message.answer("Заглушка добавления товара.")
+
+
+@router.message(F.text == "➖ Удалить товар")
+async def remove_product(message: Message):
+    if not is_admin(message.from_user.id):
+        return
+    await message.answer("Заглушка удаления товара.")
+
+
+@router.message(F.text == "⬅️ Назад")
+async def back_to_main_from_admin(message: Message):
+    if not is_admin(message.from_user.id):
+        return
+    await message.answer(
+        "🏠 Главное меню",
+        reply_markup=get_main_keyboard(is_admin=True)
+    )
+

--- a/handlers/ai_lawyer.py
+++ b/handlers/ai_lawyer.py
@@ -9,6 +9,7 @@ from keyboards.main_keyboard import (
     get_cancel_keyboard,
     get_ai_lawyer_actions_keyboard  # Новый импорт!
 )
+from config import ADMIN_IDS
 from services.openai_service import OpenAIService
 from database.db import Database
 from states.states import AIHelper
@@ -42,7 +43,10 @@ async def process_ai_question(message: Message, state: FSMContext, db: Database)
     """Обработка вопроса для AI-помощника"""
     if message.text.lower() == "❌ отмена":
         await state.clear()
-        await message.answer("❌ Действие отменено.", reply_markup=get_main_keyboard())
+        await message.answer(
+            "❌ Действие отменено.",
+            reply_markup=get_main_keyboard(is_admin=message.from_user.id in ADMIN_IDS)
+        )
         return
 
     question = message.text.strip()
@@ -116,5 +120,8 @@ async def ai_lawyer_ask_again(call: CallbackQuery, state: FSMContext):
 @router.callback_query(F.data == "ai_lawyer:to_main")
 async def ai_lawyer_to_main(call: CallbackQuery, state: FSMContext):
     await state.clear()
-    await call.message.answer("Вы вернулись в главное меню.", reply_markup=get_main_keyboard())
+    await call.message.answer(
+        "Вы вернулись в главное меню.",
+        reply_markup=get_main_keyboard(is_admin=call.from_user.id in ADMIN_IDS)
+    )
     await call.answer()

--- a/handlers/common.py
+++ b/handlers/common.py
@@ -4,6 +4,7 @@ from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 
 from keyboards.main_keyboard import get_main_keyboard
+from config import ADMIN_IDS
 
 router = Router()
 
@@ -26,7 +27,7 @@ async def cmd_start(message: Message, state: FSMContext):
     await message.answer(
         f"Пожалуйста, выберите нужный раздел в меню ниже.\n\n"
         f"Если вы не уверены, с чего начать — нажмите <b>«Помощь»</b>.",
-        reply_markup=get_main_keyboard()
+        reply_markup=get_main_keyboard(is_admin=message.from_user.id in ADMIN_IDS)
     )
 
 # Обработчик кнопки «🏠 Главное меню»
@@ -36,7 +37,7 @@ async def cmd_home(message: Message, state: FSMContext):
     # Повторяем логику главного меню
     await message.answer(
         "Вы вернулись в главное меню.",
-        reply_markup=get_main_keyboard()
+        reply_markup=get_main_keyboard(is_admin=message.from_user.id in ADMIN_IDS)
     )
 
 # Обработчик команды и кнопки /help и «Помощь»
@@ -54,5 +55,5 @@ async def cmd_help(message: Message, state: FSMContext):
         "🕯️ Уголок памяти — создать мемориал\n"
         "👤 Регистрация — зарегистрировать вас в системе\n\n"
         "Просто нажмите на нужную кнопку внизу.",
-        reply_markup=get_main_keyboard()
+        reply_markup=get_main_keyboard(is_admin=message.from_user.id in ADMIN_IDS)
     )

--- a/handlers/memory.py
+++ b/handlers/memory.py
@@ -8,6 +8,7 @@ from states.states import MemoryRecord
 from keyboards.main_keyboard import (
     get_memory_keyboard, get_memory_record_keyboard, get_cancel_keyboard, get_main_keyboard
 )
+from config import ADMIN_IDS
 from database.db import Database
 from services.memory_service import MemoryService
 
@@ -50,7 +51,10 @@ async def process_memory_photo(message: Message, state: FSMContext):
     """Обработка фото для записи памяти"""
     if message.text and message.text.lower() == "❌ отмена":
         await state.clear()
-        await message.answer("❌ Создание записи отменено.", reply_markup=get_main_keyboard())
+        await message.answer(
+            "❌ Создание записи отменено.",
+            reply_markup=get_main_keyboard(is_admin=message.from_user.id in ADMIN_IDS)
+        )
         return
     
     photo_path = None
@@ -88,7 +92,10 @@ async def process_memory_name(message: Message, state: FSMContext):
     """Обработка имени для записи памяти"""
     if message.text.lower() == "❌ отмена":
         await state.clear()
-        await message.answer("❌ Создание записи отменено.", reply_markup=get_main_keyboard())
+        await message.answer(
+            "❌ Создание записи отменено.",
+            reply_markup=get_main_keyboard(is_admin=message.from_user.id in ADMIN_IDS)
+        )
         return
     
     if not message.text or len(message.text.strip()) < 2:
@@ -109,7 +116,10 @@ async def process_birth_date(message: Message, state: FSMContext):
     """Обработка даты рождения"""
     if message.text.lower() == "❌ отмена":
         await state.clear()
-        await message.answer("❌ Создание записи отменено.", reply_markup=get_main_keyboard())
+        await message.answer(
+            "❌ Создание записи отменено.",
+            reply_markup=get_main_keyboard(is_admin=message.from_user.id in ADMIN_IDS)
+        )
         return
     
     # Простая валидация даты
@@ -131,7 +141,10 @@ async def process_death_date(message: Message, state: FSMContext):
     """Обработка даты смерти"""
     if message.text.lower() == "❌ отмена":
         await state.clear()
-        await message.answer("❌ Создание записи отменено.", reply_markup=get_main_keyboard())
+        await message.answer(
+            "❌ Создание записи отменено.",
+            reply_markup=get_main_keyboard(is_admin=message.from_user.id in ADMIN_IDS)
+        )
         return
     
     # Простая валидация даты
@@ -153,7 +166,10 @@ async def process_memory_text(message: Message, state: FSMContext, db: Database)
     """Обработка текста памяти и создание записи"""
     if message.text.lower() == "❌ отмена":
         await state.clear()
-        await message.answer("❌ Создание записи отменено.", reply_markup=get_main_keyboard())
+        await message.answer(
+            "❌ Создание записи отменено.",
+            reply_markup=get_main_keyboard(is_admin=message.from_user.id in ADMIN_IDS)
+        )
         return
     
     if not message.text or len(message.text.strip()) < 10:

--- a/handlers/registration.py
+++ b/handlers/registration.py
@@ -15,6 +15,7 @@ from keyboards.main_keyboard import (
     get_main_keyboard,
     get_cancel_keyboard
 )
+from config import ADMIN_IDS
 from database.db import Database
 
 router = Router()
@@ -215,7 +216,10 @@ async def confirm_registration(callback: CallbackQuery, state: FSMContext, db: D
         text += "Для возврата в главное меню нажмите кнопку ниже."
         
         await callback.message.edit_text(text, parse_mode="HTML")
-        await callback.message.answer("🏠 Главное меню", reply_markup=get_main_keyboard())
+        await callback.message.answer(
+            "🏠 Главное меню",
+            reply_markup=get_main_keyboard(is_admin=callback.from_user.id in ADMIN_IDS)
+        )
     else:
         text = "❌ <b>Ошибка при сохранении данных</b>\n\n"
         text += "Пожалуйста, попробуйте еще раз или обратитесь к администратору."
@@ -231,7 +235,10 @@ async def cancel_registration(callback: CallbackQuery, state: FSMContext):
     
     await state.clear()
     await callback.message.edit_text("❌ Регистрация отменена.")
-    await callback.message.answer("🏠 Главное меню", reply_markup=get_main_keyboard())
+    await callback.message.answer(
+        "🏠 Главное меню",
+        reply_markup=get_main_keyboard(is_admin=callback.from_user.id in ADMIN_IDS)
+    )
 
 @router.callback_query(F.data == "registration:back")
 async def back_to_registration(callback: CallbackQuery):
@@ -475,4 +482,7 @@ async def process_relationship(message: Message, state: FSMContext):
 async def cancel_input(message: Message, state: FSMContext):
     """Отмена ввода данных"""
     await state.clear()
-    await message.answer("❌ Ввод данных отменен.", reply_markup=get_main_keyboard()) 
+    await message.answer(
+        "❌ Ввод данных отменен.",
+        reply_markup=get_main_keyboard(is_admin=message.from_user.id in ADMIN_IDS)
+    )

--- a/handlers/voice.py
+++ b/handlers/voice.py
@@ -6,6 +6,7 @@ from aiogram.types import Message, CallbackQuery, Voice, InlineKeyboardMarkup, I
 from aiogram.fsm.context import FSMContext
 from services.openai_service import OpenAIService
 from keyboards.main_keyboard import get_main_keyboard
+from config import ADMIN_IDS
 from states.states import AIHelper, ClientRegistration, FuneralForm, MemoryRecord
 
 router = Router()
@@ -129,7 +130,10 @@ async def confirm_voice(callback: CallbackQuery, state: FSMContext, db):
         await process_memory_text(fake_message, state, db)
     else:
         await callback.message.answer(f"📝 Распознанный текст:\n<code>{transcript}</code>", parse_mode="HTML")
-        await callback.message.answer("Выберите действие из меню.", reply_markup=get_main_keyboard())
+        await callback.message.answer(
+            "Выберите действие из меню.",
+            reply_markup=get_main_keyboard(is_admin=callback.from_user.id in ADMIN_IDS)
+        )
     await state.update_data(voice_transcript=None, voice_state=None)
     await callback.answer()
 
@@ -217,4 +221,7 @@ async def cancel_voice(callback: CallbackQuery, state: FSMContext):
     await callback.answer("Отправка голосового сообщения отменена")
     await state.clear()
     await callback.message.edit_text("❌ Отправка голосового сообщения отменена.")
-    await callback.message.answer("🏠 Главное меню", reply_markup=get_main_keyboard()) 
+    await callback.message.answer(
+        "🏠 Главное меню",
+        reply_markup=get_main_keyboard(is_admin=callback.from_user.id in ADMIN_IDS)
+    )

--- a/keyboards/main_keyboard.py
+++ b/keyboards/main_keyboard.py
@@ -6,16 +6,27 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder, ReplyKeyboardBuilder
 from typing import List
 
 # Главная клавиатура (ReplyKeyboard)
-def get_main_keyboard() -> ReplyKeyboardMarkup:
+def get_main_keyboard(is_admin: bool = False) -> ReplyKeyboardMarkup:
     builder = ReplyKeyboardBuilder()
     builder.add(KeyboardButton(text="🏛️ Организация похорон"))
     builder.add(KeyboardButton(text="🤖 AI-помощник по документам"))
     builder.add(KeyboardButton(text="🛍️ Товары"))
     builder.add(KeyboardButton(text="🕯️ Уголок памяти"))
     builder.add(KeyboardButton(text="👤 Регистрация"))
+    if is_admin:
+        builder.add(KeyboardButton(text="🛠 Админ-панель"))
     builder.add(KeyboardButton(text="🏠 Главное меню"))
     builder.add(KeyboardButton(text="ℹ️ Помощь"))
     builder.adjust(2)
+    return builder.as_markup(resize_keyboard=True, one_time_keyboard=False)
+
+# Клавиатура админ-панели
+def get_admin_panel_keyboard() -> ReplyKeyboardMarkup:
+    builder = ReplyKeyboardBuilder()
+    builder.add(KeyboardButton(text="➕ Добавить товар"))
+    builder.add(KeyboardButton(text="➖ Удалить товар"))
+    builder.add(KeyboardButton(text="⬅️ Назад"))
+    builder.adjust(1)
     return builder.as_markup(resize_keyboard=True, one_time_keyboard=False)
 
 # Клавиатура выбора услуг для похорон (inline)

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from database.db import Database
 from handlers import common, funeral, ai_lawyer, shop, memory
 from handlers import registration
 from handlers import voice
+from handlers import admin_panel
 
 
 async def main():
@@ -49,6 +50,7 @@ async def main():
     dp.include_router(shop.router)
     dp.include_router(memory.router)
     dp.include_router(registration.router)
+    dp.include_router(admin_panel.router)
     dp.include_router(voice.router)
     logger.info('Роутеры успешно зарегистрированы')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ aiogram==3.4.1
 openai==1.12.0
 python-dotenv==1.0.1
 aiofiles==23.2.1
-jinja2==3.1.3 
+jinja2==3.1.3
+pytest==7.4.2

--- a/tests/test_keyboards.py
+++ b/tests/test_keyboards.py
@@ -1,0 +1,21 @@
+import pytest
+from keyboards.main_keyboard import get_main_keyboard, get_admin_panel_keyboard
+
+
+def extract(btn_markup):
+    return [btn.text for row in btn_markup.keyboard for btn in row]
+
+
+def test_admin_button_present():
+    buttons = extract(get_main_keyboard(is_admin=True))
+    assert "🛠 Админ-панель" in buttons
+
+
+def test_admin_button_absent():
+    buttons = extract(get_main_keyboard(is_admin=False))
+    assert "🛠 Админ-панель" not in buttons
+
+
+def test_admin_panel_keyboard():
+    buttons = extract(get_admin_panel_keyboard())
+    assert buttons == ["➕ Добавить товар", "➖ Удалить товар", "⬅️ Назад"]


### PR DESCRIPTION
## Summary
- allow multiple ADMIN_IDS in config
- show Admin panel button in main menu for admins
- add admin panel keyboard and handlers
- include new router in main bot startup
- add unit tests for keyboards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_6878cb3536848321a694394853600e17