### PR TITLE
Implement product addition flow

### DIFF
--- a/database/db.py
+++ b/database/db.py
@@ -224,6 +224,23 @@ class Database:
         
         conn.close()
         return products
+
+    async def add_product(self, name: str, price: float, category: str = None,
+                           description: str = None, photo_path: str = "photos/placeholder.jpg"):
+        """Добавление нового товара"""
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        cursor.execute(
+            """
+            INSERT INTO products (name, description, price, category, photo_path)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (name, description, price, category, photo_path)
+        )
+
+        conn.commit()
+        conn.close()
     
     async def create_memory_record(self, telegram_id: int, name: str, birth_date: str, death_date: str, memory_text: str, photo_path: str, html_path: str):
         """Создание записи памяти"""

--- a/handlers/admin_panel.py
+++ b/handlers/admin_panel.py
@@ -1,11 +1,29 @@
 from aiogram import Router, F
-from aiogram.types import Message
+from aiogram.types import Message, CallbackQuery, InlineKeyboardButton
 from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 from config import ADMIN_IDS
-from keyboards.main_keyboard import get_main_keyboard, get_admin_panel_keyboard
+from keyboards.main_keyboard import (
+    get_main_keyboard,
+    get_admin_panel_keyboard,
+    get_cancel_keyboard,
+)
+from states.states import AddProduct
+from database.db import Database
 
 router = Router()
+
+
+def get_confirm_keyboard(step: str):
+    builder = InlineKeyboardBuilder()
+    builder.add(
+        InlineKeyboardButton(text="✅ Подтвердить", callback_data=f"add_product:{step}:confirm"),
+        InlineKeyboardButton(text="✏️ Редактировать", callback_data=f"add_product:{step}:edit"),
+    )
+    builder.adjust(2)
+    return builder.as_markup()
 
 
 def is_admin(user_id: int) -> bool:
@@ -22,10 +40,102 @@ async def admin_menu(message: Message):
 
 
 @router.message(F.text == "➕ Добавить товар")
-async def add_product(message: Message):
+async def add_product(message: Message, state: FSMContext):
     if not is_admin(message.from_user.id):
         return
-    await message.answer("Заглушка добавления товара.")
+    await state.set_state(AddProduct.waiting_for_name)
+    await message.answer(
+        "Введите вид товара:",
+        reply_markup=get_cancel_keyboard(),
+    )
+
+
+@router.message(AddProduct.waiting_for_name)
+async def process_product_name(message: Message, state: FSMContext):
+    if message.text.lower() == "❌ отмена":
+        await state.clear()
+        await message.answer(
+            "❌ Добавление товара отменено.",
+            reply_markup=get_admin_panel_keyboard(),
+        )
+        return
+
+    name = message.text.strip()
+    await state.update_data(name=name)
+    await state.set_state(AddProduct.confirm_name)
+    await message.answer(
+        f"Вид товара: <b>{name}</b>",
+        reply_markup=get_confirm_keyboard("name"),
+    )
+
+
+@router.callback_query(F.data == "add_product:name:confirm")
+async def confirm_product_name(callback: CallbackQuery, state: FSMContext):
+    await callback.answer()
+    await state.set_state(AddProduct.waiting_for_price)
+    await callback.message.edit_text(
+        "Введите цену товара:",
+        reply_markup=get_cancel_keyboard(),
+    )
+
+
+@router.callback_query(F.data == "add_product:name:edit")
+async def edit_product_name(callback: CallbackQuery, state: FSMContext):
+    await callback.answer()
+    await state.set_state(AddProduct.waiting_for_name)
+    await callback.message.edit_text(
+        "Введите вид товара:",
+        reply_markup=get_cancel_keyboard(),
+    )
+
+
+@router.message(AddProduct.waiting_for_price)
+async def process_product_price(message: Message, state: FSMContext):
+    if message.text.lower() == "❌ отмена":
+        await state.clear()
+        await message.answer(
+            "❌ Добавление товара отменено.",
+            reply_markup=get_admin_panel_keyboard(),
+        )
+        return
+
+    try:
+        price = float(message.text.replace(",", "."))
+    except ValueError:
+        await message.answer("Введите корректную цену:")
+        return
+
+    await state.update_data(price=price)
+    await state.set_state(AddProduct.confirm_price)
+    await message.answer(
+        f"Цена товара: {price} ₽",
+        reply_markup=get_confirm_keyboard("price"),
+    )
+
+
+@router.callback_query(F.data == "add_product:price:confirm")
+async def confirm_product_price(callback: CallbackQuery, state: FSMContext, db: Database):
+    await callback.answer()
+    data = await state.get_data()
+    name = data.get("name")
+    price = data.get("price")
+    await db.add_product(name=name, price=price)
+    await state.clear()
+    await callback.message.edit_text("✅ Товар добавлен.")
+    await callback.message.answer(
+        "🛠 <b>Админ-панель</b>",
+        reply_markup=get_admin_panel_keyboard(),
+    )
+
+
+@router.callback_query(F.data == "add_product:price:edit")
+async def edit_product_price(callback: CallbackQuery, state: FSMContext):
+    await callback.answer()
+    await state.set_state(AddProduct.waiting_for_price)
+    await callback.message.edit_text(
+        "Введите цену товара:",
+        reply_markup=get_cancel_keyboard(),
+    )
 
 
 @router.message(F.text == "➖ Удалить товар")

--- a/handlers/registration.py
+++ b/handlers/registration.py
@@ -481,6 +481,11 @@ async def process_relationship(message: Message, state: FSMContext):
 @router.message(F.text == "❌ Отмена")
 async def cancel_input(message: Message, state: FSMContext):
     """Отмена ввода данных"""
+    current_state = await state.get_state()
+    if current_state and not current_state.startswith(
+        ("ClientRegistration", "FuneralForm", "MemoryRecord", "AIHelper")
+    ):
+        return
     await state.clear()
     await message.answer(
         "❌ Ввод данных отменен.",

--- a/states/states.py
+++ b/states/states.py
@@ -36,4 +36,12 @@ class AdminStates(StatesGroup):
 
 class AIHelper(StatesGroup):
     """Состояния для AI-помощника"""
-    waiting_for_question = State() 
+    waiting_for_question = State()
+
+
+class AddProduct(StatesGroup):
+    """Состояния для добавления товара администратором"""
+    waiting_for_name = State()
+    confirm_name = State()
+    waiting_for_price = State()
+    confirm_price = State()


### PR DESCRIPTION
## Summary
- add FSM states for adding a product
- allow admins to input product name and price with confirmation steps
- implement DB helper to save new products
- refine cancel handler to ignore admin states

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_6878d934c6688321b2c868c1a6a09b91